### PR TITLE
Move chunking and dedup to Lambda, remove DocumentService from SearchService

### DIFF
--- a/app/services/dependencies.py
+++ b/app/services/dependencies.py
@@ -43,10 +43,7 @@ def get_search_service() -> SearchService:
         A SearchService configured from environment variables.
     """
 
-    return SearchService(
-        config=SearchConfig.from_env(),
-        document_service=get_document_service(),
-    )
+    return SearchService(config=SearchConfig.from_env())
 
 
 def get_http_session_from_app(app: FastAPI) -> aiohttp.ClientSession:

--- a/app/services/search_service.py
+++ b/app/services/search_service.py
@@ -17,7 +17,6 @@ from app.models.search import (
     SearchResponse,
 )
 from app.services.config import SearchConfig
-from app.services.document_service import DocumentService
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +32,8 @@ class SearchService:
     ``asyncio.to_thread()`` so FastAPI routes remain non-blocking.
     """
 
-    def __init__(self, config: SearchConfig, document_service: DocumentService) -> None:
+    def __init__(self, config: SearchConfig) -> None:
         self._config = config
-        self._document_service = document_service
 
     # ------------------------------------------------------------------
     # Client factory (replaceable in tests)
@@ -135,9 +133,11 @@ class SearchService:
         chunk_size: int = 500,
         chunk_overlap: int = 50,
     ) -> IndexDocumentResponse:
-        """Index a single document, splitting it into chunks first.
+        """Index a single document via Lambda.
 
-        Skips indexing if the filename is already present in the index.
+        Lambda handles chunking and dedup (skip_existing). A single Lambda
+        call replaces the previous pattern of document_exists + chunk_text
+        + index_documents.
 
         Args:
             filename: Source document filename.
@@ -154,21 +154,12 @@ class SearchService:
         if not content or not content.strip():
             raise ValueError("content must be provided")
 
-        # Skip if already indexed.
-        if await self.document_exists(filename=filename):
-            return IndexDocumentResponse(filename=filename, chunk_count=0, doc_ids=[], skipped=True)
-
-        chunks = self._document_service.chunk_text(
-            text=content,
-            chunk_size=chunk_size,
-            chunk_overlap=chunk_overlap,
-        )
-        if not chunks:
-            return IndexDocumentResponse(filename=filename, chunk_count=0, doc_ids=[], skipped=False)
-
         payload = {
             "action": "index_documents",
-            "documents": [{"filename": filename, "chunks": chunks}],
+            "documents": [{"filename": filename, "content": content}],
+            "skip_existing": True,
+            "chunk_size": chunk_size,
+            "chunk_overlap": chunk_overlap,
         }
 
         try:
@@ -178,6 +169,10 @@ class SearchService:
         except Exception as exc:
             logger.exception("Search index_document Lambda call failed for %s", filename)
             raise SearchServiceError(f"Failed to index document: {filename}") from exc
+
+        skipped_filenames = raw.get("skipped_filenames", [])
+        if filename in skipped_filenames:
+            return IndexDocumentResponse(filename=filename, chunk_count=0, doc_ids=[], skipped=True)
 
         doc_ids = raw.get("doc_ids", [])
         return IndexDocumentResponse(

--- a/lambda_search/handler.py
+++ b/lambda_search/handler.py
@@ -294,27 +294,63 @@ def _handle_search(event: dict[str, Any]) -> dict[str, Any]:
 
 
 def _handle_index_documents(event: dict[str, Any]) -> dict[str, Any]:
+    """Index documents into the search index.
+
+    Each document can provide either:
+    - ``chunks``: list of pre-chunked strings (backward compatible)
+    - ``content``: raw text that will be chunked by Lambda
+
+    Optional ``skip_existing`` (default False) skips documents whose
+    filename is already in the corpus.
+    """
+
     global _corpus, _artifacts_loaded
 
     _load_artifacts()
     if _corpus is None:
         _corpus = []
 
-    documents = event["documents"]  # [{filename, chunks: [str]}]
+    skip_existing = event.get("skip_existing", False)
+    existing_filenames = {doc["filename"] for doc in _corpus} if skip_existing else set()
+
+    documents = event["documents"]
     all_doc_ids: list[str] = []
+    skipped_filenames: list[str] = []
 
     for doc in documents:
         filename = doc["filename"]
-        chunks = doc["chunks"]
+
+        if skip_existing and filename in existing_filenames:
+            skipped_filenames.append(filename)
+            continue
+
+        # Determine chunks: use pre-chunked if provided, otherwise chunk raw content
+        if "chunks" in doc:
+            chunks = doc["chunks"]
+        elif "content" in doc:
+            from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+            chunk_size = event.get("chunk_size", 500)
+            chunk_overlap = event.get("chunk_overlap", 50)
+            splitter = RecursiveCharacterTextSplitter(
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap,
+            )
+            chunks = splitter.split_text(doc["content"])
+        else:
+            continue
+
         for chunk in chunks:
             doc_id = str(uuid.uuid4())
             _corpus.append({"doc_id": doc_id, "filename": filename, "content": chunk})
             all_doc_ids.append(doc_id)
 
-    _rebuild_indexes()
-    _save_artifacts()
+        existing_filenames.add(filename)
 
-    return {"doc_ids": all_doc_ids}
+    if all_doc_ids:
+        _rebuild_indexes()
+        _save_artifacts()
+
+    return {"doc_ids": all_doc_ids, "skipped_filenames": skipped_filenames}
 
 
 def _handle_document_exists(event: dict[str, Any]) -> dict[str, Any]:

--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -9,7 +9,6 @@ import pytest
 
 from app.models.search import IndexDocumentRequest
 from app.services.config import SearchConfig
-from app.services.document_service import DocumentService
 from app.services.search_service import SearchService, SearchServiceError
 
 
@@ -48,25 +47,6 @@ class FakeLambdaClient:
 
 
 # ---------------------------------------------------------------------------
-# Stub DocumentService (returns predictable chunks)
-# ---------------------------------------------------------------------------
-
-
-class StubDocumentService(DocumentService):
-    """DocumentService that skips Bedrock and returns canned chunk results."""
-
-    def __init__(self, chunks: list[str] | None = None) -> None:
-        self._embedding_model_id = ""
-        self._embedding_dim = 1024
-        self._chunks = chunks if chunks is not None else ["chunk-0", "chunk-1"]
-
-    def chunk_text(self, *, text: str, chunk_size: int = 500, chunk_overlap: int = 50) -> list[str]:
-        if not text or not text.strip():
-            return []
-        return list(self._chunks)
-
-
-# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -78,12 +58,8 @@ _DEFAULT_CONFIG = SearchConfig(
 )
 
 
-def _make_service(
-    fake: FakeLambdaClient,
-    stub_doc: StubDocumentService | None = None,
-) -> SearchService:
-    doc = stub_doc or StubDocumentService()
-    service = SearchService(config=_DEFAULT_CONFIG, document_service=doc)
+def _make_service(fake: FakeLambdaClient) -> SearchService:
+    service = SearchService(config=_DEFAULT_CONFIG)
     service._client = lambda: fake  # type: ignore[method-assign]
     return service
 
@@ -169,21 +145,10 @@ def test_list_indexed_documents_wraps_errors():
 # ===========================================================================
 
 
-def test_index_document_indexes_chunks():
+def test_index_document_indexes_via_lambda():
+    """Single Lambda call with content field — no document_exists round-trip."""
     fake = FakeLambdaClient()
-    call_count = {"n": 0}
-    original_invoke = fake.invoke
-
-    def _invoke(**kwargs: Any) -> dict[str, Any]:
-        call_count["n"] += 1
-        payload = json.loads(kwargs["Payload"])
-        if payload["action"] == "document_exists":
-            fake.set_response({"exists": False})
-        elif payload["action"] == "index_documents":
-            fake.set_response({"doc_ids": ["id-0", "id-1"]})
-        return original_invoke(**kwargs)
-
-    fake.invoke = _invoke  # type: ignore[method-assign]
+    fake.set_response({"doc_ids": ["id-0", "id-1"], "skipped_filenames": []})
     service = _make_service(fake)
 
     resp = asyncio.run(service.index_document(filename="doc.md", content="some text"))
@@ -192,17 +157,24 @@ def test_index_document_indexes_chunks():
     assert resp.doc_ids == ["id-0", "id-1"]
     assert resp.skipped is False
 
+    # Single Lambda call — no document_exists preceding it
+    assert len(fake.calls) == 1
+    payload = json.loads(fake.calls[0][1]["Payload"])
+    assert payload["action"] == "index_documents"
+    assert payload["documents"][0]["content"] == "some text"
+    assert payload["skip_existing"] is True
+
 
 def test_index_document_skips_when_already_indexed():
     fake = FakeLambdaClient()
-    fake.set_response({"exists": True})
+    fake.set_response({"doc_ids": [], "skipped_filenames": ["existing.md"]})
     service = _make_service(fake)
 
     resp = asyncio.run(service.index_document(filename="existing.md", content="text"))
     assert resp.skipped is True
     assert resp.chunk_count == 0
     assert resp.doc_ids == []
-    # Only document_exists was called
+    # Still only one Lambda call (index_documents with skip_existing)
     assert len(fake.calls) == 1
 
 
@@ -222,11 +194,11 @@ def test_index_document_raises_on_blank_content():
         asyncio.run(service.index_document(filename="doc.md", content=""))
 
 
-def test_index_document_empty_chunks_returns_zero():
+def test_index_document_no_chunks_returns_zero():
+    """Lambda returns no doc_ids when content produces no chunks."""
     fake = FakeLambdaClient()
-    fake.set_response({"exists": False})
-    stub_doc = StubDocumentService(chunks=[])
-    service = _make_service(fake, stub_doc)
+    fake.set_response({"doc_ids": [], "skipped_filenames": []})
+    service = _make_service(fake)
 
     resp = asyncio.run(service.index_document(filename="tiny.md", content="x"))
     assert resp.chunk_count == 0
@@ -245,18 +217,16 @@ def test_bulk_index_documents_mixes_new_and_existing():
 
     def _invoke(**kwargs: Any) -> dict[str, Any]:
         payload = json.loads(kwargs["Payload"])
-        if payload["action"] == "document_exists":
-            if payload["filename"] == "old.md":
-                fake.set_response({"exists": True})
+        if payload["action"] == "index_documents":
+            filename = payload["documents"][0]["filename"]
+            if filename == "old.md":
+                fake.set_response({"doc_ids": [], "skipped_filenames": ["old.md"]})
             else:
-                fake.set_response({"exists": False})
-        elif payload["action"] == "index_documents":
-            fake.set_response({"doc_ids": ["new-1"]})
+                fake.set_response({"doc_ids": ["new-1"], "skipped_filenames": []})
         return original_invoke(**kwargs)
 
     fake.invoke = _invoke  # type: ignore[method-assign]
-    stub_doc = StubDocumentService(chunks=["only-chunk"])
-    service = _make_service(fake, stub_doc)
+    service = _make_service(fake)
 
     docs = [
         IndexDocumentRequest(filename="old.md", content="already indexed"),
@@ -272,7 +242,15 @@ def test_bulk_index_documents_mixes_new_and_existing():
 
 def test_bulk_index_documents_all_skipped():
     fake = FakeLambdaClient()
-    fake.set_response({"exists": True})
+    original_invoke = fake.invoke
+
+    def _invoke(**kwargs: Any) -> dict[str, Any]:
+        payload = json.loads(kwargs["Payload"])
+        filename = payload["documents"][0]["filename"]
+        fake.set_response({"doc_ids": [], "skipped_filenames": [filename]})
+        return original_invoke(**kwargs)
+
+    fake.invoke = _invoke  # type: ignore[method-assign]
     service = _make_service(fake)
 
     docs = [


### PR DESCRIPTION
## Summary
- Extended Lambda `index_documents` to accept raw `content` field (Lambda chunks it) alongside existing `chunks` field (backward compatible)
- Added `skip_existing` flag for server-side dedup, eliminating the `document_exists` round-trip
- `SearchService.index_document()` reduced from 3 Lambda calls to 1 (was: exists check → local chunking → index; now: single index call with content + skip_existing)
- Removed `DocumentService` dependency from `SearchService` constructor
- Reworked `StubDocumentService` out of search service tests

Closes #19

## Merge Order
**PR 3 of 3** (Phase 1: Stabilization & Architecture Cleanup)
**Must be merged after PR 2** (`feat/lambda-build-index`). Base branch is `feat/lambda-build-index` — after PR 2 merges, rebase this onto main.

1. `feat/mcp-tools-rework` — MCP tools rework (#10)
2. `feat/lambda-build-index` — Lambda build_index + FastAPI delegation (#17, #18)
3. ✅ **This PR** — Lambda chunking + dedup (**depends on #2**)

## Test plan
- [x] All 101 tests pass (index tests reworked for single-call pattern)
- [x] `ruff check` clean
- [ ] Deploy Lambda first (backward-compatible `chunks` field still works)
- [ ] `POST /search/index` makes a single Lambda call (no `document_exists` preceding)
- [ ] Old callers sending `chunks` to Lambda still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)